### PR TITLE
Fixed tab video issue

### DIFF
--- a/client/src/components/Video.jsx
+++ b/client/src/components/Video.jsx
@@ -6,7 +6,7 @@ export const Video = ({stream}) => {
         if (videoRef && videoRef.current) {
             videoRef.current.srcObject = stream;
         }
-      }, [videoRef])
+      }, [videoRef, stream])
     
       return (
         <div>


### PR DESCRIPTION
To summarize, the Video component receives a video stream as a prop, creates a reference to the video element, and then uses a useEffect to ensure that the stream is attached as the srcObject of the video element whenever the component mounts or the stream changes.

![image](https://github.com/100xDevs-hkirat/gmeet-webrtc/assets/86650576/4aad8f1e-f6c9-4408-86ba-9cda4f11c057)
![image](https://github.com/100xDevs-hkirat/gmeet-webrtc/assets/86650576/348e1159-ef26-4af8-8c70-96d71967d38d)

